### PR TITLE
App layout + Ability to add new nodes to the graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "export": "next export",
     "deploy": "yarn build && yarn export -o build",
     "docker": "yarn deploy && docker-compose up -d",
-    "docker-down": "docker-compose down "
+    "docker-down": "docker-compose down",
+    "run-ci": "gh workflow run -r $(git rev-parse --abbrev-ref HEAD)",
+    "view-ci": "gh run view"
   },
   "dependencies": {
     "@ant-design/icons": "^4.7.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,7 +3,6 @@ import Head from "next/head";
 import { useEffect } from "react";
 import styled, { ThemeProvider } from "styled-components";
 import theme from "../src/util/styles";
-import { assetPrefix } from "../src/util/utils";
 import "./app.global.css";
 
 const Footer = styled.footer`
@@ -23,7 +22,8 @@ export default function App({ Component, pageProps }: AppProps): JSX.Element {
       <Head>
         <title>Machinist</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, shrink-to-fit=no" />
-        <link rel="icon"       href={`${assetPrefix}/favicon.ico`} />
+        {/* <link rel="icon"       href={`${assetPrefix}/favicon.ico`} /> */}
+        <link rel="icon" href="https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/160/twitter/31/baby-chick_1f424.png" />
         <link rel="preconnect" href="https://fonts.gstatic.com" />
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=B612:wght@700&display=swap" />
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:wght@300&display=swap" />
@@ -31,7 +31,7 @@ export default function App({ Component, pageProps }: AppProps): JSX.Element {
       <ThemeProvider theme={theme}>
         <Component {...pageProps} />
       </ThemeProvider>
-      <Footer>My App</Footer>
+      <Footer>Machinist</Footer>
     </>
   );
 }

--- a/pages/app.global.css
+++ b/pages/app.global.css
@@ -15,14 +15,6 @@ body {
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
 }
 
-/* main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-} */
-
 footer {
   width: 100%;
   min-height: 5em;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,68 +1,35 @@
 import styled from "styled-components";
-import { Canvas } from "./canvas/Canvas";
-import { GraphProvider, useGraph } from "./data/graph";
+import Canvas from "./canvas/Canvas";
+import { GraphProvider } from "./data/graph";
 import { KeyChordsProvider } from "./data/keychords";
+import MenuBar from "./menubar/MenuBar";
 
-const canvasBackgroundColor = "#F6F8FA";
+// const canvasBackgroundColor = "#F6F8FA";
 
-const Content = styled.section``;
-
-const DemoGraphViewerRoot = styled.div`
-  width: 100%;
-  height: 100%;
-
-  display: flex;
-  flex-direction: column;
-  place-items: center;
-
-  & > div {
-    width: 50%;
-  }
+const Main = styled.main`
+  height: 100vh;
+  width: 100vw;
 `;
 
-const DemoGraphViewer = () => {
-  const graph = useGraph();
+const FullscreenCanvas = styled(Canvas)`
+  width: 100%;
+  height: 100%;
+`;
 
-  return (
-    <DemoGraphViewerRoot>
-      <h1>GRAPH STORE:</h1>
-      <div>
-        <pre>
-          {JSON.stringify(
-            graph.states.map((s) => ({ ...s, ref: null })),
-            null,
-            2
-          )}
-        </pre>
-      </div>
-    </DemoGraphViewerRoot>
-  );
-};
-
-const Center = styled.div`
-  display: flex;
-  flex-direction: column;
-  place-content: center;
-  place-items: center;
-
-  margin: 10em 0px;
+const FloatingMenuBar = styled(MenuBar)`
+  position: absolute;
+  inset: 30% auto auto 1rem;
+  z-index: 100;
 `;
 
 const App = (): JSX.Element => (
   <KeyChordsProvider>
     <GraphProvider>
-      <main style={{ backgroundColor: canvasBackgroundColor, height: "100vh" }}>
-        <Content>
-          <Center>
-            <div>
-              {/* <State id="q1" /> */}
-              <Canvas />
-              {/* <MenuBar /> */}
-              {/* <DemoGraphViewer /> */}
-            </div>
-          </Center>
-        </Content>
-      </main>
+      <Main>
+        <FullscreenCanvas />
+        <FloatingMenuBar />
+        {/* <GraphStoreDebugger /> */}
+      </Main>
     </GraphProvider>
   </KeyChordsProvider>
 );

--- a/src/components/canvas/Canvas.tsx
+++ b/src/components/canvas/Canvas.tsx
@@ -1,4 +1,3 @@
-import { Button } from "antd";
 import { ComponentPropsWithoutRef, useCallback, useEffect } from "react";
 import styled from "styled-components";
 import { origin, ref, useGraphActions } from "../data/graph";
@@ -11,12 +10,15 @@ const Root = styled.div`
   position: relative;
 `;
 
-const Canvas = ({ ...props }: ComponentPropsWithoutRef<"div">): JSX.Element => {
+type CanvasProps = ComponentPropsWithoutRef<"div">;
+
+const Canvas = ({ ...props }: CanvasProps): JSX.Element => {
   const { dispatch } = useGraphActions();
   const buttonRef = ref<HTMLButtonElement>(null);
 
   const clear = useCallback(() => dispatch({ type: "CLEAR" }), [dispatch]);
-  const add = useCallback(
+
+  const addInitial = useCallback(
     () =>
       dispatch({
         type: "ADD",
@@ -47,18 +49,33 @@ const Canvas = ({ ...props }: ComponentPropsWithoutRef<"div">): JSX.Element => {
     [dispatch]
   );
 
+  const addFresh = useCallback(
+    () =>
+      dispatch({
+        type: "ADD",
+        state: {
+          id: "q_",
+          ending: false,
+          location: { x: 0, y: 0 },
+          ref: null,
+        },
+      }),
+    [dispatch]
+  );
+
   useEffect(() => {
-    dispatch({
-      type: "SET_SIZE",
-      size: (s) => ({ ...s, width: 500, height: 300 }),
-    });
-    add();
-    return clear;
-  }, [clear, add, dispatch]);
+    addInitial();
+    return () =>
+      dispatch({
+        type: "REMOVE",
+        ids: ["q0", "q1", "t0"],
+      });
+  }, [clear, addInitial, dispatch]);
 
   return (
     <Root {...props}>
-      <Button
+      {/* TODO: FLAP-71 - Move this buttons to the sidebar */}
+      {/* <Button
         ref={buttonRef}
         style={{
           display: "relative",
@@ -73,11 +90,10 @@ const Canvas = ({ ...props }: ComponentPropsWithoutRef<"div">): JSX.Element => {
           display: "relative",
           inset: "-50px auto auto 100px",
         }}
-        onClick={add}
+        onClick={addFresh}
       >
         ADD
-      </Button>
-
+      </Button> */}
       <EdgeLayer />
       <NodeLayer />
     </Root>
@@ -85,4 +101,4 @@ const Canvas = ({ ...props }: ComponentPropsWithoutRef<"div">): JSX.Element => {
 };
 
 export default Canvas;
-export { Canvas };
+export type { CanvasProps };

--- a/src/components/canvas/layers/EdgeLayer.tsx
+++ b/src/components/canvas/layers/EdgeLayer.tsx
@@ -17,9 +17,6 @@ const Root: StyledComponent<"svg", DefaultTheme> = styled.svg.attrs(
   box-sizing: border-box;
 
   text-align: center;
-  /* !!! DEBUG !!! */
-  border: 1px solid black;
-  /* !!! DEBUG !!! */
 `;
 
 type EdgeLayerProps = ComponentPropsWithoutRef<"svg">;
@@ -28,7 +25,7 @@ const EdgeLayer = ({ ...props }: EdgeLayerProps): JSX.Element => {
   const graph = useGraph();
   const { setRoot } = useGraphActions();
   const root = useRef<SVGSVGElement>(null);
-  const viewBox = useMemo(() => graph.vb(), [graph]);
+  const viewBox = useMemo(() => "0 0 100% 100%", []);
 
   useEffect(() => {
     setRoot(root);

--- a/src/components/canvas/node/State.tsx
+++ b/src/components/canvas/node/State.tsx
@@ -107,7 +107,7 @@ const State = memo(
     // When the node gets unrendered, it removes its reference from the store
     useEffect(() => {
       modifyState({ id, ref: me });
-      return () => modifyState({ id, ref: null });
+      // return () => modifyState({ id, ref: null });
     }, []);
 
     return (

--- a/src/components/debug/GraphStoreDebugger.tsx
+++ b/src/components/debug/GraphStoreDebugger.tsx
@@ -1,0 +1,42 @@
+import styled from "styled-components";
+import { useGraph } from "../data/graph";
+
+const DemoGraphViewerRoot = styled.div`
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  place-items: center;
+
+  & > div {
+    width: 50%;
+    word-wrap: break-word;
+  }
+`;
+
+const GraphStoreDebugger = (): JSX.Element => {
+  const graph = useGraph();
+
+  return (
+    <DemoGraphViewerRoot>
+      <h1>GRAPH STORE:</h1>
+      <div>
+        <pre>
+          {JSON.stringify(
+            graph.states.map((s) => ({
+              ...s,
+              ref: s.ref?.current?.tagName
+                ? `Ref: <${s.ref?.current?.tagName.toLowerCase()}>`
+                : null,
+            })),
+            null,
+            2
+          )}
+        </pre>
+      </div>
+    </DemoGraphViewerRoot>
+  );
+};
+
+export default GraphStoreDebugger;

--- a/src/components/menubar/MenuBar.tsx
+++ b/src/components/menubar/MenuBar.tsx
@@ -8,27 +8,28 @@ import {
 } from "@ant-design/icons";
 import { Button, Menu } from "antd";
 import SubMenu from "antd/lib/menu/SubMenu";
-import { useCallback, useState } from "react";
-import styled, { StyledComponent } from "styled-components";
+import { ComponentPropsWithoutRef, useCallback, useState } from "react";
+import styled from "styled-components";
+import theme from "../../util/styles";
 
-const Root = styled.div`
-  width: 256px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
+const Root = styled.div``;
 
 const ToggleButton = styled(Button)`
-  margin-bottom: 16px;
+  margin-bottom: 2px;
+  width: 100%;
 `;
 
 const ToggleIcon = styled(DoubleLeftOutlined)<{ $collapsed?: boolean }>`
   transform: rotate(90deg);
-  transition: cubic-bezier(0.075, 0.82, 0.165, 1);
+  &&& {
+    transition: transform 0.3s ${theme.transitions.atndMenuBarBezier};
+  }
   ${({ $collapsed }) => $collapsed && `transform: rotate(-90deg)`}
 `;
 
-const MenuBar = (): JSX.Element => {
+type MenuBarProps = ComponentPropsWithoutRef<"div">;
+
+const MenuBar = ({ ...props }: MenuBarProps): JSX.Element => {
   const [state, setState] = useState({ collapsed: false });
 
   const toggle = useCallback(
@@ -37,10 +38,7 @@ const MenuBar = (): JSX.Element => {
   );
 
   return (
-    <Root>
-      <ToggleButton type="primary" onClick={toggle}>
-        <ToggleIcon $collapsed={state.collapsed} />
-      </ToggleButton>
+    <Root {...props}>
       <Menu
         mode="inline"
         theme="light"
@@ -48,6 +46,13 @@ const MenuBar = (): JSX.Element => {
         defaultSelectedKeys={["1"]}
         defaultOpenKeys={["sub1"]}
       >
+        {/* <Menu.Item> */}
+        <li>
+          <ToggleButton type="primary" onClick={toggle}>
+            <ToggleIcon $collapsed={state.collapsed} />
+          </ToggleButton>
+        </li>
+        {/* </Menu.Item> */}
         <Menu.Item key="1" icon={<PieChartOutlined />}>
           Option 1
         </Menu.Item>
@@ -77,5 +82,4 @@ const MenuBar = (): JSX.Element => {
 };
 
 export default MenuBar;
-
-export { MenuBar };
+export type { MenuBarProps };

--- a/src/types/styled.d.ts
+++ b/src/types/styled.d.ts
@@ -25,8 +25,24 @@ declare module "styled-components" {
     };
 
     transitions: {
+      /**
+       * A medium cubiz-bezier
+       */
       lifted: string;
+
+      /**
+       * A fast cubic-bezier
+       */
       liftedFast: string;
+
+      /**
+       * The cubic-bezier used in the antd Menu component
+       */
+      atndMenuBarBezier: string;
+
+      /**
+       * Some other unknown property
+       */
       [key: string]: string;
     };
 

--- a/src/util/styles.ts
+++ b/src/util/styles.ts
@@ -33,6 +33,7 @@ const theme: DefaultTheme = {
   transitions: {
     lifted: "all 700ms cubic-bezier(0.75, 0, 0.25, 1)",
     liftedFast: "all 0.2s cubic-bezier(0.075, 0.82, 0.165, 1)",
+    atndMenuBarBezier: "cubic-bezier(0.215, 0.61, 0.355, 1)",
   },
 
   mixins: {


### PR DESCRIPTION
# Description

This PR adds the general layout for the app (a minimal sidebar plus some main
content where you can draw the graph).

You can now also double-click on the canvas to generate a new node underneath
the mouse.

## Link to work item

Closes FLAP-52
Closes FLAP-60

## How to Test

To test out these changes, run the app (`yarn dev`) and view the home page.
