### PR TITLE
Flap 74 text labels on transitions

### DIFF
--- a/src/components/canvas/labels/Labels.tsx
+++ b/src/components/canvas/labels/Labels.tsx
@@ -1,0 +1,80 @@
+import { ComponentPropsWithoutRef, useMemo } from "react";
+import styled, { DefaultTheme, StyledComponent } from "styled-components";
+import { midPoint, Point, useGraph } from "../../data/graph";
+import { Text } from "../node/State";
+
+type LabelRootComponent = StyledComponent<
+  "p",
+  DefaultTheme,
+  {
+    theme: DefaultTheme;
+  } & {
+    $x?: number;
+    $y?: number;
+  },
+  never
+>;
+
+const LabelRoot: LabelRootComponent = styled(Text).attrs<{
+  $x?: number;
+  $y?: number;
+}>(({ $x, $y }) => ({
+  style: {
+    transform: `
+      translate(calc(${$x ?? 0}px - 50%), calc(${$y ?? 0}px - 50%))
+    `,
+  },
+}))`
+  position: absolute;
+  inset: 0 auto auto 0;
+
+  font-size: 1.25rem;
+  height: 1.5em;
+  border-radius: 50%;
+  //border: 1px solid green;
+  background: rgba(255, 255, 255, 0.8);
+`;
+
+type LabelProps = ComponentPropsWithoutRef<"p"> & { point: Point };
+const Label = ({
+  children,
+  point: { x, y },
+  ...props
+}: LabelProps): JSX.Element => (
+  <LabelRoot $x={x} $y={y} {...props}>
+    {children}
+  </LabelRoot>
+);
+
+const Labels = (): JSX.Element => {
+  const graph = useGraph();
+
+  // The transitions store start and end states by state id, we need to search
+  // the graph to find the locations for each state
+  const transitions = useMemo(
+    () =>
+      graph.transitions.map((t) => ({
+        ...t,
+        start: graph.states.find((s) => s.id === t.start.state),
+        end: graph.states.find((s) => s.id === t.end.state),
+      })),
+    [graph]
+  );
+
+  return (
+    <>
+      {}
+      {transitions.map((t) => (
+        <Label
+          key={`transition-label_${t.id}_${t.symbol}`}
+          point={midPoint(t.start.location, t.end.location)}
+        >
+          {t.symbol}
+        </Label>
+      ))}
+    </>
+  );
+};
+
+export { Labels, Label, LabelRoot };
+export type { LabelProps, LabelRootComponent as LabelRootProps };

--- a/src/components/canvas/layers/NodeLayer.tsx
+++ b/src/components/canvas/layers/NodeLayer.tsx
@@ -18,6 +18,7 @@ import {
   State as GraphState,
   useGraphAndGraphActions,
 } from "../../data/graph";
+import { Labels } from "../labels/Labels";
 import { State, StateRoot } from "../node/State";
 
 const Root = styled.div`
@@ -214,6 +215,7 @@ const NodeLayer = ({ ...props }: NodeLayerProps): JSX.Element => {
       onMouseUp={stopDragging}
       onMouseMove={onMouseMove}
     >
+      <Labels />
       {graph.states.map(stateAndIndexToElement)}
     </Root>
   );

--- a/src/components/canvas/node/State.tsx
+++ b/src/components/canvas/node/State.tsx
@@ -126,4 +126,4 @@ const State = memo(
 
 State.displayName = "State";
 
-export { State, StateRoot };
+export { State, StateRoot, Text };

--- a/src/components/canvas/node/Transition.tsx
+++ b/src/components/canvas/node/Transition.tsx
@@ -7,6 +7,7 @@ import {
   Transition as GraphTransition,
   useGraphActions,
   computeLine,
+  midPoint,
 } from "../../data/graph";
 
 const svgNs = "http://www.w3.org/2000/svg";
@@ -51,11 +52,6 @@ const Transition = memo(
         point: s.point,
         scalingFactor,
       });
-
-    const midPoint = (p1: Point, p2: Point): Point => ({
-      x: Math.min(p2.x, p1.x) + Math.abs(p2.x - p1.x) / 2,
-      y: Math.min(p2.y, p1.y) + Math.abs(p2.y - p1.y) / 2,
-    });
 
     const startState = graph.pointForState(transition.start.state);
     const endState = graph.pointForState(transition.end.state);

--- a/src/components/data/graph.tsx
+++ b/src/components/data/graph.tsx
@@ -120,6 +120,11 @@ type GraphActionsContextType = {
 
 const origin = (): Point => ({ x: 0, y: 0 });
 
+const midPoint = (p1: Point, p2: Point): Point => ({
+  x: Math.min(p2.x, p1.x) + Math.abs(p2.x - p1.x) / 2,
+  y: Math.min(p2.y, p1.y) + Math.abs(p2.y - p1.y) / 2,
+});
+
 const computeLine = (p1: Point, p2: Point): { a: number; b: number } => {
   const a = (p2.y - p1.y) / (p2.x - p1.x);
   const b = p1.y - a * p1.x;
@@ -598,6 +603,7 @@ export {
   ref,
   blankGraph,
   origin,
+  midPoint,
   computeLine,
   computeThirdPoint,
   pointIsAtEdgeOfCircle,


### PR DESCRIPTION
# Description

fixed css class creation that slowed app. styled label with slightly transparent circular background and slightly reduced text size while removing border

## Link to work item

FLAP-74
https://flapflap.atlassian.net/jira/software/projects/FLAP/boards/1?selectedIssue=FLAP-74

## How to Test

yarn dev and view text labels attached to transition lines
